### PR TITLE
remove instructions to use npm for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ This plugin is [Serverless][link-serverless] variables reimagined, making them c
 ## Installation
 
 ```sh
-npm install -D serverless-plugin-composed-vars
-```
-or
-```sh
 yarn add -D serverless-plugin-composed-vars
 ```
 


### PR DESCRIPTION
Since npm fails with 'use yarn' it seems like instructions telling people to use it are a bit misleading